### PR TITLE
Add richer 8-bit environment backgrounds

### DIFF
--- a/ecco/environment.py
+++ b/ecco/environment.py
@@ -36,6 +36,14 @@ def draw_environment(surf, env_type, offset, time_val):
         for x in range(0, w, 50):
             dx = x - (offset % 50)
             pygame.draw.line(surf, (20, 80, 40), (dx, h-30), (dx, h-10), 2)
+        # Small rocks and rising bubbles for extra detail
+        for x in range(20, w, 80):
+            dx = x - (offset % 80)
+            pygame.draw.ellipse(surf, (80, 70, 50), (dx, h - 15, 20, 10))
+        for x in range(0, w, 60):
+            dx = x - (offset % 60)
+            by = h - 30 - ((time_val // 10 + x) % 60)
+            pygame.draw.circle(surf, (200, 200, 255), (dx, by), 2)
 
     elif env_type == Environment.ROCKY_REEF:
         surf.fill((20, 50, 80))
@@ -51,6 +59,13 @@ def draw_environment(surf, env_type, offset, time_val):
             dx = x - (offset % 45)
             sway = int(math.sin(time_val*0.002 + x) * 5)
             pygame.draw.line(surf, (30, 100, 60), (dx, h-60), (dx+sway, h-20), 3)
+        # Small fish weaving through the reef
+        for x in range(0, w, 75):
+            dx = x - (offset % 75)
+            fy = h - 100 + int(math.sin(time_val*0.004 + x) * 10)
+            pygame.draw.ellipse(surf, (200, 120, 80), (dx, fy, 14, 7))
+            pygame.draw.polygon(surf, (220, 140, 90),
+                                [(dx+14, fy+3), (dx+18, fy), (dx+18, fy+7)])
 
     elif env_type == Environment.CORAL_COVE:
         for y in range(h):
@@ -75,6 +90,11 @@ def draw_environment(surf, env_type, offset, time_val):
             pygame.draw.ellipse(surf, (200, 80, 80), (dx, fy, 12, 6))
             pygame.draw.polygon(surf, (220, 100, 100),
                                 [(dx+12, fy+3), (dx+16, fy), (dx+16, fy+6)])
+        # Clams on the seabed
+        for x in range(0, w, 70):
+            dx = x - (offset % 70)
+            pygame.draw.circle(surf, (200, 180, 160), (dx, h - 10), 5)
+            pygame.draw.line(surf, (150, 130, 110), (dx-3, h-5), (dx+3, h-5), 2)
 
     elif env_type == Environment.BEACH:
         surf.fill((100, 180, 220))
@@ -89,6 +109,11 @@ def draw_environment(surf, env_type, offset, time_val):
         pygame.draw.circle(surf, (255, 255, 200), (w-40, 40), 20)
         for cx in range(0, w, 100):
             pygame.draw.ellipse(surf, (250, 250, 255), (cx-20, 10, 60, 20))
+        # Seagulls flying overhead
+        for bx in range(0, w, 90):
+            by = 20 + int(math.sin(time_val * 0.002 + bx) * 5)
+            pygame.draw.line(surf, (255, 255, 255), (bx, by), (bx+6, by-3), 2)
+            pygame.draw.line(surf, (255, 255, 255), (bx+6, by-3), (bx+12, by), 2)
 
     elif env_type == Environment.OIL_RIG:
         surf.fill((30, 40, 45))
@@ -107,3 +132,11 @@ def draw_environment(surf, env_type, offset, time_val):
         if int(time_val*0.002) % 2 == 0:
             drop_x = (time_val//20 % w)
             pygame.draw.circle(surf, (10, 10, 20), (int(drop_x), h-40), 3)
+        # Blinking warning lights and water ripples
+        for x in range(0, w + 120, 120):
+            dx = x - (offset % 120)
+            light_color = (255, 180, 80) if int(time_val*0.004) % 2 == 0 else (120, 100, 50)
+            pygame.draw.circle(surf, light_color, (dx, 15), 3)
+        for x in range(0, w, 40):
+            ry = h - 20 + int(math.sin(time_val*0.003 + x) * 2)
+            pygame.draw.line(surf, (40, 50, 60), (x, ry), (x + 20, ry), 1)


### PR DESCRIPTION
## Summary
- Add rocks and bubbles to the ocean floor
- Introduce fish and more reef life to rocky reef and coral cove
- Render seagulls, blinking lights, and water ripples for beach and oil rig scenes

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b1071b6db48333a3c9c1c8911eff47