### PR TITLE
Add ambient audio loops with crossfade

### DIFF
--- a/ecco/config.py
+++ b/ecco/config.py
@@ -20,6 +20,11 @@ SFX_HURT_FILE = ASSET_DIR / 'sfx_hurt_synth.wav'
 SFX_DASH_FILE = ASSET_DIR / 'sfx_dash_synth.wav'
 SFX_POWERUP_FILE = ASSET_DIR / 'sfx_powerup_synth.wav'
 
+# Ambient loops
+AMBIENT_WAVES_FILE = ASSET_DIR / 'ambient_waves.wav'
+AMBIENT_GULLS_FILE = ASSET_DIR / 'ambient_gulls.wav'
+AMBIENT_HUM_FILE = ASSET_DIR / 'ambient_hum.wav'
+
 SAVE_FILE = DATA_DIR / 'tide_highscore.json'
 
 POWERUP_THRESHOLD = 15

--- a/ecco/game.py
+++ b/ecco/game.py
@@ -10,7 +10,7 @@ from pygame.locals import *
 from .config import (TITLE, DEFAULT_W, DEFAULT_H, SCALE, FPS,
                      POWERUP_THRESHOLD, POWERUP_DURATION, SAVE_FILE)
 from .environment import Environment, draw_environment
-from .sound import load_or_generate_audio, play_sfx, _sfx
+from .sound import load_or_generate_audio, play_sfx, _sfx, update_ambient
 
 
 # Graceful message if pygame isn't installed
@@ -699,8 +699,9 @@ def run():
     title_font = pygame.font.SysFont("consolas", 22, bold=True)
     
     # Audio
-    music_map, eat, hurt, dash, powerup = load_or_generate_audio()
+    music_map, _ambient_map, eat, hurt, dash, powerup = load_or_generate_audio()
     pygame.mixer.music.load(music_map[Environment.BEACH])
+    update_ambient(Environment.BEACH)
     
     _sfx["eat"] = pygame.mixer.Sound(eat)
     _sfx["hurt"] = pygame.mixer.Sound(hurt)
@@ -743,12 +744,13 @@ def run():
     bubbles = []
     
     # Environment management
-    environments = [Environment.BEACH, Environment.CORAL_COVE, Environment.ROCKY_REEF, 
+    environments = [Environment.BEACH, Environment.CORAL_COVE, Environment.ROCKY_REEF,
                    Environment.OCEAN_FLOOR, Environment.OIL_RIG]
     current_env_index = 0
     current_env = environments[current_env_index]
     env_transition = 0
     distance_traveled = 0
+    update_ambient(current_env)
     
     # Side-scrolling variables
     scroll_speed = 30  # pixels per second
@@ -830,6 +832,7 @@ def run():
                     current_env = environments[current_env_index]
                     pygame.mixer.music.load(music_map[current_env])
                     pygame.mixer.music.play(-1)
+                    update_ambient(current_env)
                     
                     # Respawn entities
                     for _ in range(5):
@@ -858,6 +861,7 @@ def run():
                 current_env = environments[current_env_index]
                 pygame.mixer.music.load(music_map[current_env])
                 pygame.mixer.music.play(-1)
+                update_ambient(current_env)
                 # spawn fresh food in new environment
                 for _ in range(3):
                     jellies.append(


### PR DESCRIPTION
## Summary
- Generate ambient wave, gull, and machinery hum loops
- Crossfade ambient tracks when environments change
- Trigger ambient loop updates from the game

## Testing
- `python -m py_compile ecco/config.py ecco/sound.py ecco/game.py`


------
https://chatgpt.com/codex/tasks/task_e_68b109fd96508333a6e16e911a2aa70f