### PR TITLE
feat: add day-night cycle

### DIFF
--- a/ecco/environment.py
+++ b/ecco/environment.py
@@ -7,19 +7,68 @@ class Environment:
     CORAL_COVE = "Coral Cove"
     BEACH = "Beach Shallows"
     OIL_RIG = "Oil Rig"
+def _lerp(a, b, t):
+    return a + (b - a) * t
 
 
-def draw_environment(surf, env_type, offset, time_val):
+def _lerp_color(c1, c2, t):
+    return tuple(int(_lerp(c1[i], c2[i], t)) for i in range(3))
+
+
+def draw_environment(surf, env_type, offset, time_val, time_of_day):
     w, h = surf.get_width(), surf.get_height()
-    # clear previous frame to avoid artifacts
-    surf.fill((0, 0, 0))
+
+    # --- Time of day colour selection ---
+    t = time_of_day % 24.0
+    day_sky = (135, 206, 235)
+    day_water = (0, 105, 148)
+    dawn_sky = (255, 150, 80)
+    dawn_water = (60, 110, 130)
+    dusk_sky = (255, 100, 60)
+    dusk_water = (0, 60, 90)
+    night_sky = (10, 10, 40)
+    night_water = (0, 20, 30)
+
+    overlay_alpha = 0
+    moon_alpha = 0
+    if 6 <= t < 8:  # dawn
+        r = (t - 6) / 2
+        sky_color = _lerp_color(dawn_sky, day_sky, r)
+        water_color = _lerp_color(dawn_water, day_water, r)
+        overlay_alpha = int(120 * (1 - r))
+        moon_alpha = int(255 * (1 - r))
+    elif 8 <= t < 18:  # day
+        sky_color = day_sky
+        water_color = day_water
+    elif 18 <= t < 20:  # dusk
+        r = (t - 18) / 2
+        sky_color = _lerp_color(day_sky, dusk_sky, r)
+        water_color = _lerp_color(day_water, dusk_water, r)
+        overlay_alpha = int(120 * r)
+        moon_alpha = int(255 * r)
+    else:  # night
+        sky_color = night_sky
+        water_color = night_water
+        overlay_alpha = 120
+        moon_alpha = 255
+        if t < 6:  # fade out towards dawn
+            r = t / 6
+            sky_color = _lerp_color(night_sky, dawn_sky, r)
+            water_color = _lerp_color(night_water, dawn_water, r)
+            overlay_alpha = int(120 * (1 - r))
+            moon_alpha = int(255 * (1 - r))
+
+    # clear previous frame to avoid artifacts and apply base water colour
+    surf.fill(water_color)
 
     if env_type == Environment.OCEAN_FLOOR:
         for y in range(h):
             depth = y / h
-            c = int(20 - depth * 15)
-            b = int(60 - depth * 30)
-            pygame.draw.line(surf, (5, c, b), (0, y), (w, y))
+            line_col = _lerp_color(water_color,
+                                   (max(0, water_color[0] - 30),
+                                    max(0, water_color[1] - 50),
+                                    max(0, water_color[2] - 70)), depth)
+            pygame.draw.line(surf, line_col, (0, y), (w, y))
         for x in range(0, w + 40, 40):
             dx = x - (offset % 40)
             height = 10 + int(math.sin((x + offset) * 0.02) * 5)
@@ -38,7 +87,6 @@ def draw_environment(surf, env_type, offset, time_val):
             pygame.draw.line(surf, (20, 80, 40), (dx, h-30), (dx, h-10), 2)
 
     elif env_type == Environment.ROCKY_REEF:
-        surf.fill((20, 50, 80))
         for x in range(0, w + 60, 60):
             dx = x - (offset % 60)
             pygame.draw.rect(surf, (60, 65, 70),
@@ -55,10 +103,11 @@ def draw_environment(surf, env_type, offset, time_val):
     elif env_type == Environment.CORAL_COVE:
         for y in range(h):
             depth = y / h
-            r = int(30 + depth * 20)
-            g = int(140 - depth * 40)
-            b = int(180 - depth * 30)
-            pygame.draw.line(surf, (r, g, b), (0, y), (w, y))
+            line_col = _lerp_color(water_color,
+                                   (water_color[0] + 30,
+                                    max(0, water_color[1] - 40),
+                                    max(0, water_color[2] - 30)), depth)
+            pygame.draw.line(surf, line_col, (0, y), (w, y))
         for x in range(0, w + 50, 50):
             dx = x - (offset % 50)
             pygame.draw.circle(surf, (255, 120, 150), (dx, h - 20), 15)
@@ -77,21 +126,30 @@ def draw_environment(surf, env_type, offset, time_val):
                                 [(dx+12, fy+3), (dx+16, fy), (dx+16, fy+6)])
 
     elif env_type == Environment.BEACH:
-        surf.fill((100, 180, 220))
+        pygame.draw.rect(surf, sky_color, (0, 0, w, h//3))
+        pygame.draw.rect(surf, water_color, (0, h//3, w, h - h//3))
         for x in range(0, w, 30):
             sx = x + int(math.sin(time_val * 0.001 + x) * 10)
-            pygame.draw.line(surf, (150, 210, 240), (sx, 0), (sx - 20, h), 2)
+            pygame.draw.line(surf, _lerp_color(water_color, sky_color, 0.3),
+                             (sx, h//3), (sx - 20, h), 2)
         pygame.draw.rect(surf, (230, 210, 170), (0, h - 30, w, 30))
         for x in range(0, w + 40, 40):
             dx = x - (offset % 40)
             pygame.draw.circle(surf, (255, 230, 200), (dx, h - 15), 3)
-        # Sun and clouds
-        pygame.draw.circle(surf, (255, 255, 200), (w-40, 40), 20)
-        for cx in range(0, w, 100):
-            pygame.draw.ellipse(surf, (250, 250, 255), (cx-20, 10, 60, 20))
+        # Sun and clouds (hidden at night)
+        sun_alpha = 0 if overlay_alpha else 255
+        if sun_alpha:
+            sun = pygame.Surface((40, 40), pygame.SRCALPHA)
+            pygame.draw.circle(sun, (255, 255, 200), (20, 20), 20)
+            sun.set_alpha(sun_alpha)
+            surf.blit(sun, (w - 60, 10))
+            for cx in range(0, w, 100):
+                cloud = pygame.Surface((60, 20), pygame.SRCALPHA)
+                pygame.draw.ellipse(cloud, (250, 250, 255), (0, 0, 60, 20))
+                cloud.set_alpha(sun_alpha)
+                surf.blit(cloud, (cx - 20, 10))
 
     elif env_type == Environment.OIL_RIG:
-        surf.fill((30, 40, 45))
         for x in range(0, w + 120, 120):
             dx = x - (offset % 120)
             pygame.draw.rect(surf, (80, 80, 80), (dx - 5, 0, 10, h))
@@ -107,3 +165,15 @@ def draw_environment(surf, env_type, offset, time_val):
         if int(time_val*0.002) % 2 == 0:
             drop_x = (time_val//20 % w)
             pygame.draw.circle(surf, (10, 10, 20), (int(drop_x), h-40), 3)
+
+    # --- Night overlay and moon ---
+    if overlay_alpha > 0:
+        overlay = pygame.Surface((w, h), pygame.SRCALPHA)
+        overlay.fill((0, 0, 40, overlay_alpha))
+        surf.blit(overlay, (0, 0))
+
+    if moon_alpha > 0:
+        moon = pygame.Surface((30, 30), pygame.SRCALPHA)
+        pygame.draw.circle(moon, (240, 240, 255), (15, 15), 12)
+        moon.set_alpha(moon_alpha)
+        surf.blit(moon, (w - 50, 20))

--- a/ecco/game.py
+++ b/ecco/game.py
@@ -13,6 +13,9 @@ from .environment import Environment, draw_environment
 from .sound import load_or_generate_audio, play_sfx, _sfx
 
 
+DAY_LENGTH = 60.0  # seconds for a full day-night cycle
+
+
 # Graceful message if pygame isn't installed
 def _msgbox(title, text):
     try:
@@ -764,6 +767,7 @@ def run():
     highscore = load_highscore(highscore_path)
     
     t = 0.0
+    time_of_day = 6.0  # start around dawn
     
     # Spawn initial entities
     for _ in range(5):
@@ -781,6 +785,7 @@ def run():
     while True:
         dt = clock.tick(FPS)
         t += dt
+        time_of_day = (time_of_day + (dt / 1000.0) * (24.0 / DAY_LENGTH)) % 24.0
         
         for e in pygame.event.get():
             if e.type == QUIT:
@@ -974,7 +979,7 @@ def run():
                 save_highscore(highscore_path, highscore)
         
         # Draw everything
-        draw_environment(base, current_env, int(world_offset), int(t))
+        draw_environment(base, current_env, int(world_offset), int(t), time_of_day)
         
         # Draw entities
         for j in jellies:


### PR DESCRIPTION
## Summary
- introduce time_of_day tracking and day length constant
- tint environment based on time of day and show moon overlay at night

## Testing
- `python -m py_compile ecco/game.py ecco/environment.py`


------
https://chatgpt.com/codex/tasks/task_e_68b109f445408333813b7a5b65dd096e